### PR TITLE
cloud: replace tofu compilations with the prepared action

### DIFF
--- a/.github/workflows/infrastruct.yml
+++ b/.github/workflows/infrastruct.yml
@@ -28,7 +28,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Setup tofu tooling
-      uses: opentofu/setup-opentofu
+      uses: opentofu/setup-opentofu@v1.0.0
 
     - name: Prepare the cloud directory
       working-directory: ./cloud

--- a/.github/workflows/infrastruct.yml
+++ b/.github/workflows/infrastruct.yml
@@ -27,23 +27,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
-    - name: Download the tofu source
-      uses: actions/checkout@v4
-      with:
-        repository: opentofu/opentofu
-        path: opentofu
-
-    - name: Install tofu tooling
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: opentofu/go.mod
-        cache-dependency-path: opentofu/go.sum
-
-    - name: Prepare the tofu command
-      working-directory: opentofu
-      run: |
-        go build -ldflags "-w -s -X 'github.com/opentofu/opentofu/version.dev=no'" -o bin/tofu .
-        echo $(pwd)/bin >> $GITHUB_PATH
+    - name: Setup tofu tooling
+      uses: opentofu/setup-opentofu
 
     - name: Prepare the cloud directory
       working-directory: ./cloud


### PR DESCRIPTION
something broke in [this action run](https://github.com/zimeg/.DOTFILES/actions/runs/6620538342/job/17983130281):

> package github.com/opentofu/opentofu: build constraints exclude all Go files in /home/runner/work/.DOTFILES/.DOTFILES/opentofu

and the official setup-opentofu now exists!