### PR TITLE
feat(tom): add openclaw-gateway as a system service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-openclaw = {
+      url = "github:openclaw/nix-openclaw";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixpkgs = {
       url = "github:NixOS/nixpkgs/nixos-unstable";
     };
@@ -166,6 +170,7 @@
             ./machines/tom/configuration.nix
             inputs.home-manager.nixosModules.home-manager
             inputs.impermanence.nixosModules.impermanence
+            inputs.nix-openclaw.nixosModules.openclaw-gateway
             inputs.sops-nix.nixosModules.sops
             {
               home-manager = {

--- a/machines/tom/configuration.nix
+++ b/machines/tom/configuration.nix
@@ -60,6 +60,7 @@
     ./services/interception-tools
     ./services/minecraft-server
     ./services/ollama
+    ./services/openclaw-gateway
     ./services/openssh
     ./services/pipewire
     ./services/plasma6
@@ -93,6 +94,7 @@
       "/etc/ollama/models"
       "/srv/minecraft/world"
       "/var/lib/nixos"
+      "/var/lib/openclaw"
       "/var/lib/slack"
       "/var/lib/soft-serve"
       "/var/lib/systemd/coredump"

--- a/machines/tom/services/openclaw-gateway/default.nix
+++ b/machines/tom/services/openclaw-gateway/default.nix
@@ -1,0 +1,14 @@
+# https://github.com/openclaw/openclaw
+{ ... }:
+{
+  services.openclaw-gateway = {
+    enable = true;
+    port = 18789;
+    user = "openclaw";
+    group = "openclaw";
+    stateDir = "/var/lib/openclaw";
+    environment = {
+      NODE_ENV = "production";
+    };
+  };
+}


### PR DESCRIPTION
Adds the [nix-openclaw](https://github.com/openclaw/nix-openclaw) flake input and enables the `openclaw-gateway` NixOS module on TOM. This runs the OpenClaw gateway under a dedicated `openclaw` system user with persistent state at `/var/lib/openclaw`.

## Changes

- Add `nix-openclaw` flake input (follows nixpkgs)
- Import `openclaw-gateway` NixOS module in the `tom` NixOS configuration
- Create `machines/tom/services/openclaw-gateway/default.nix` with service config
- Persist `/var/lib/openclaw` across reboots via impermanence

## Notes

- The gateway listens on port `18789` (default) — you may want to add this to the firewall `allowedTCPPorts` if external access is needed
- `environmentFiles` can be used to inject secrets (API keys, tokens) via sops — not wired up yet since I don't know the secret structure you'd want
- The module creates the `openclaw` user/group automatically via `createUser = true` (default)