### PR TITLE
tom: add loopback tinyproxy service

### DIFF
--- a/machines/tom/configuration.nix
+++ b/machines/tom/configuration.nix
@@ -77,6 +77,7 @@
     ./services/sddm
     ./services/soft-serve
     ./services/tailscale
+    ./services/tinyproxy
     ./services/xserver
     ./systemd/services
     ./systemd/targets

--- a/machines/tom/services/tinyproxy/default.nix
+++ b/machines/tom/services/tinyproxy/default.nix
@@ -1,0 +1,12 @@
+# https://tinyproxy.github.io/
+{
+  services.tinyproxy = {
+    enable = true;
+    settings = {
+      Allow = [ "127.0.0.1" ];
+      Listen = "127.0.0.1";
+      Port = 3128;
+      Timeout = 600;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add a minimal tinyproxy service module on tom
- bind it to 127.0.0.1:3128 and allow only localhost
- import the module from tom's system configuration

## Validation
- nix eval .#nixosConfigurations.tom.config.services.tinyproxy.enable
- nix eval .#nixosConfigurations.tom.config.services.tinyproxy.settings.Port

Related: zimeg/slack-sandbox#712